### PR TITLE
FIX: Add default mobile setup

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,7 +23,8 @@ module.exports = {
     'react/jsx-filename-extension': [1, { extensions: ['.js', '.jsx'] }],
     indent: ['error', 2],
     'arrow-body-style': ['error', 'always'],
-
+    quotes: ['error', 'single'],
+    'jsx-a11y/no-static-element-interactions': ['always'],
   },
   settings: {
     react: {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,9 +41,29 @@ Issue fixing
 - Added /src/globalConfig folder
 - Added /src/globalConfig/GlobalStyles.js
 
+#### #2
+- Added /src/globalConfig/mobile.js
+- Added /src/globalConfig/templates folder
+- Added /src/globalConfig/templates/styles.js file
 
 ### Changed
 
 #### #3
-- App.js
+- /src/App.js
   - Added GlobalStyles import.
+
+#### #2
+- /.eslintrc.js
+  - Added arrow-body-style rules
+  - Added quotes rule
+  - Added no-static-element-interactions rule
+- /src/globalConfig/GlobalStyles.js
+  - Added Mobile import
+  - Added default mobile breakpoints.
+- /src/StyledApp.js
+  - Added Mobile import
+  - Added default mobile breakpoints.
+- /src/components/modules/Header/StyledHeader.js
+  - Added Mobile import
+  - Added default mobile breakpoints.
+

--- a/src/components/modules/Header/StyledHeader.js
+++ b/src/components/modules/Header/StyledHeader.js
@@ -1,9 +1,47 @@
 // Library Imports
 import styled from 'styled-components'
+import media from 'globalConfig/mobile'
 
 const StyledHeader = styled.section`
+/* MOBILE FIRST DEFAULT STYLES */
   border: 1px solid #000;
   width: 100%;
+
+
+/* Min width of 375 */
+  ${media.iphoneSe `
+    
+  `}
+
+/* Min width of 414 */
+  ${media.iphoneXr `
+    
+  `}
+
+/* Min width of 576 */
+  ${media.landscapePhones `
+    
+  `}
+
+/* Min width of 768 */
+  ${media.tablet `
+    
+  `}
+
+/* Min width of 1024 */
+  ${media.desktop `
+    
+  `}
+
+/* Min width of 1200 */
+  ${media.widescreen `
+    
+  `}
+
+/* Min width of 1980 */
+  ${media.udh `
+    
+  `}
 `
 
 export default StyledHeader

--- a/src/globalConfig/GlobalStyles.js
+++ b/src/globalConfig/GlobalStyles.js
@@ -1,9 +1,8 @@
 // Library Imports
 import { createGlobalStyle } from 'styled-components'
+import media from 'globalConfig/mobile'
 
-const GlobalStyle = createGlobalStyle`
-  /* Font Family Declarations */
-  
+const GlobalStyle = createGlobalStyle`  
   /*
     START OF RESET
     http://meyerweb.com/eric/tools/css/reset/
@@ -61,6 +60,42 @@ const GlobalStyle = createGlobalStyle`
 
   /* END OF RESET */
 
+  /* MOBILE FIRST DEFAULT STYLES */
+
+  /* Min width of 375 */
+    ${media.iphoneSe `
+      
+    `}
+
+  /* Min width of 414 */
+    ${media.iphoneXr `
+      
+    `}
+
+  /* Min width of 576 */
+    ${media.landscapePhones `
+      
+    `}
+
+  /* Min width of 768 */
+    ${media.tablet `
+      
+    `}
+
+  /* Min width of 1024 */
+    ${media.desktop `
+      
+    `}
+
+  /* Min width of 1200 */
+    ${media.widescreen `
+      
+    `}
+
+  /* Min width of 1980 */
+    ${media.udh `
+      
+    `}
 `
 
 export default GlobalStyle

--- a/src/globalConfig/mobile.js
+++ b/src/globalConfig/mobile.js
@@ -1,0 +1,25 @@
+// Library Imports
+import { css } from 'styled-components'
+
+// Variable Declarations
+const sizes = {
+  udh: 1980,
+  widescreen: 1200,
+  desktop: 1024,
+  tablet: 768,
+  landscapePhones: 576,
+  iphoneXr: 414,
+  iphoneSe: 375,
+}
+
+/**
+ * This function allows us to define the size needed dynamically.
+ */
+export default Object.keys(sizes).reduce((acc, label) => {
+  acc[label] = (...args) => css `
+    @media (min-width: ${sizes[label]}px) {
+      ${css(...args)}
+    }
+  `
+  return acc
+}, {})

--- a/src/globalConfig/templates/styles.js
+++ b/src/globalConfig/templates/styles.js
@@ -1,10 +1,10 @@
 // Library Imports
-import styled from 'styled-components'
+import { createGlobalStyle } from 'styled-components'
 import media from 'globalConfig/mobile'
 
-const StyledApp = styled.section`
+const GlobalStyle = createGlobalStyle`
+
 /* MOBILE FIRST DEFAULT STYLES */
-  width: 100%;
 
 /* Min width of 375 */
   ${media.iphoneSe `
@@ -40,6 +40,5 @@ const StyledApp = styled.section`
   ${media.udh `
     
   `}
-`
 
-export default StyledApp
+`


### PR DESCRIPTION
- Added /src/globalConfig/mobile.js
- Added /src/globalConfig/templates folder
- Added /src/globalConfig/templates/styles.js file]

eslint was edited because of undefined eslint rules.
- /.eslintrc.js
  - Added arrow-body-style rules
  - Added quotes rule
  - Added no-static-element-interactions rule
- /src/globalConfig/GlobalStyles.js
  - Added Mobile import
  - Added default mobile breakpoints.
- /src/StyledApp.js
  - Added Mobile import
  - Added default mobile breakpoints.
- /src/components/modules/Header/StyledHeader.js
  - Added Mobile import
  - Added default mobile breakpoints.